### PR TITLE
WindowsPath error corrected

### DIFF
--- a/gui/gui.py
+++ b/gui/gui.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Qt, QStringListModel
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import *
 
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from typing import List, Set
 import sounddevice as sd
 import soundfile as sf
@@ -276,7 +276,7 @@ class GUI(QDialog):
         self.log(msg)
         msg += ".\nThe recognized datasets are:\n\t%s\nFeel free to add your own. You " \
              "can still use the toolbox by recording samples yourself." % \
-             ("\n\t".join(recognized_datasets))
+             ("\n\t".join(map(lambda x: str(x) if type(x) == WindowsPath else x, recognized_datasets)))
         print(msg, file=sys.stderr)
 
         self.random_utterance_button.setDisabled(True)


### PR DESCRIPTION
error occurs when ''.join([WindowsPaths]) since WindowsPath isn't string.
I don't know whether same error don't occur when Path is PosixPath. So I only corrected for WindowsPath.